### PR TITLE
Fix isNil function in mssql.ts

### DIFF
--- a/src/dialects/mssql.ts
+++ b/src/dialects/mssql.ts
@@ -11,7 +11,7 @@ const debug = require('debug')('knex:patched:mssql')
 import { setHiddenProperty } from 'knex/lib/util/security.js'
 
 function isNil(value: any): boolean {
-  return value !== undefined && value !== null
+  return value === undefined || value === null
 }
 
 /**


### PR DESCRIPTION
This change fixes the bug of requestLimit setting in database connection config being ignored.

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Fixes @adonisjs/lucid issue: [In v5, Database timeout config not being respected with MS Sql Server #930](https://github.com/adonisjs/lucid/issues/930)

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/thetutlage/knex-dynamic-connection/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)