### PR TITLE
feat: support async connection settings provider with expirationChecker

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,10 +84,31 @@ function patchKnex(knex, configFn) {
   ).acquireRawConnection
 
   /**
-   * Returns a dynamic connection to be used for each query
+   * Cached settings + expiration checker. Mirrors knex's
+   * `updatePoolConnectionSettingsFromProvider` so that `configFn` is only
+   * re-invoked when the previously returned `expirationChecker` reports
+   * the credentials as stale.
    */
-  client.getRuntimeConnectionSettings = function getRuntimeConnectionSettings() {
-    return configFn(this.config)
+  let cachedSettings = null
+  let expirationChecker = () => true
+
+  client.getRuntimeConnectionSettings = async function getRuntimeConnectionSettings() {
+    if (cachedSettings && expirationChecker && !expirationChecker()) {
+      return cachedSettings
+    }
+
+    const result = await configFn(this.config)
+
+    if (result && typeof result.expirationChecker === 'function') {
+      expirationChecker = result.expirationChecker
+      const { expirationChecker: _drop, ...rest } = result
+      cachedSettings = rest
+    } else {
+      expirationChecker = null
+      cachedSettings = result
+    }
+
+    return cachedSettings
   }
 }
 

--- a/src/dialects/mssql.js
+++ b/src/dialects/mssql.js
@@ -94,12 +94,12 @@ function generateConnection(settings) {
  * Copy of `acquireRawConnection` from knex codebase, but instead relies
  * on `getRuntimeConnectionSettings` vs `connectionSettings`
  */
-function acquireRawConnection() {
+async function acquireRawConnection() {
+  debug('connection::connection new connection requested')
+  const connectionSettings = await this.getRuntimeConnectionSettings()
   return new Promise((resolver, rejecter) => {
-    debug('connection::connection new connection requested')
-
     const Driver = this._driver()
-    const settings = Object.assign({}, generateConnection(this.getRuntimeConnectionSettings()))
+    const settings = Object.assign({}, generateConnection(connectionSettings))
 
     const connection = new Driver.Connection(settings)
 

--- a/src/dialects/mysql.js
+++ b/src/dialects/mysql.js
@@ -11,9 +11,10 @@
  * Copy of `acquireRawConnection` from knex codebase, but instead relies
  * on `getRuntimeConnectionSettings` vs `connectionSettings`
  */
-function acquireRawConnection() {
+async function acquireRawConnection() {
+  const connectionSettings = await this.getRuntimeConnectionSettings()
   return new Promise((resolver, rejecter) => {
-    const connection = this.driver.createConnection(this.getRuntimeConnectionSettings())
+    const connection = this.driver.createConnection(connectionSettings)
     connection.on('error', (err) => {
       connection.__knex__disposed = err
     })

--- a/src/dialects/oracledb.js
+++ b/src/dialects/oracledb.js
@@ -90,12 +90,11 @@ function readStream(stream, type) {
  * Copy of `acquireRawConnection` from knex codebase, but instead relies
  * on `getRuntimeConnectionSettings` vs `connectionSettings`
  */
-function acquireRawConnection() {
+async function acquireRawConnection() {
   const client = this
+  const settings = await client.getRuntimeConnectionSettings()
 
   const asyncConnection = new Promise(function (resolver, rejecter) {
-    const settings = client.getRuntimeConnectionSettings()
-
     // If external authentication don't have to worry about username/password and
     // if not need to set the username and password
     const oracleDbConfig = settings.externalAuth

--- a/src/dialects/pg.js
+++ b/src/dialects/pg.js
@@ -11,9 +11,9 @@
  * Copy of `acquireRawConnection` from knex codebase, but instead relies
  * on `getRuntimeConnectionSettings` vs `connectionSettings`
  */
-function acquireRawConnection() {
+async function acquireRawConnection() {
   const client = this
-  const connection = new client.driver.Client(client.getRuntimeConnectionSettings())
+  const connection = new client.driver.Client(await client.getRuntimeConnectionSettings())
   connection.on('error', (err) => {
     connection.__knex__disposed = err
   })

--- a/tests/patch_knex.spec.js
+++ b/tests/patch_knex.spec.js
@@ -282,6 +282,65 @@ test.group('Patch knex', (group) => {
     assert.lengthOf(users, 0)
   }).timeout(6000)
 
+  test('support async connection property in knex config', async ({ assert, cleanup }) => {
+    assert.plan(2)
+
+    let resolverCalls = 0
+    const baseConfig = getKnexConfig()
+
+    const knexInstance = knex({
+      ...baseConfig,
+      connection: async () => {
+        resolverCalls++
+        return baseConfig.connection
+      },
+    })
+    cleanup(() => knexInstance.destroy())
+
+    patchKnex(knexInstance, (config) => {
+      return typeof config.connection === 'function' ? config.connection() : config.connection
+    })
+
+    const result = await knexInstance.raw('SELECT 1 + 1 AS sum;')
+    assert.exists(result)
+    assert.isAbove(resolverCalls, 0)
+  })
+
+  test('switch hosts via async connection property', async ({ assert, cleanup }) => {
+    let counter = 0
+    const baseConfig = getKnexConfig()
+    const replicaConnection = getKnexConfigReplica().connection
+
+    const knexInstance = knex({
+      ...baseConfig,
+      connection: async () => {
+        counter++
+        if (counter === 2) {
+          return replicaConnection
+        }
+        return baseConfig.connection
+      },
+    })
+    cleanup(() => knexInstance.destroy())
+
+    patchKnex(knexInstance, (config) => config.connection())
+
+    await knexInstance.table('users').insert({ username: 'virk' })
+
+    /**
+     * Sleeping for a while, so that the pool will releases the unused
+     * connection and the callback to compute connection settings
+     * will re-trigger.
+     */
+    await sleep(1000)
+    const users = await knexInstance.table('users').select('*')
+
+    await sleep(1000)
+    await knexInstance('users').truncate()
+
+    assert.lengthOf(users, 0)
+  }).timeout(6000)
+
   test('do not re-acquire connection in transaction', async ({ assert, cleanup }) => {
     let counter = 0
 
@@ -306,4 +365,42 @@ test.group('Patch knex', (group) => {
     assert.lengthOf(users, 1)
     assert.equal(counter, 1)
   }).timeout(6000)
+
+  test('cache settings while expirationChecker returns false', async ({ assert, cleanup }) => {
+    let configCalls = 0
+    let expired = false
+
+    const knexInstance = knex(getKnexConfig())
+    cleanup(() => knexInstance.destroy())
+
+    patchKnex(knexInstance, async () => {
+      configCalls++
+      return {
+        ...getKnexConfig().connection,
+        expirationChecker: () => expired,
+      }
+    })
+
+    await knexInstance.raw('SELECT 1 + 1 AS sum;')
+
+    /**
+     * Sleeping so the pool releases the idle connection. A fresh acquire
+     * triggers `getRuntimeConnectionSettings` again — but the cached
+     * settings should be reused since the checker still returns false.
+     */
+    await sleep(1000)
+    await knexInstance.raw('SELECT 1 + 1 AS sum;')
+
+    assert.equal(configCalls, 1)
+
+    /**
+     * Flip the flag — checker now returns true. Next acquire must
+     * re-invoke `configFn` to refresh credentials.
+     */
+    expired = true
+    await sleep(1000)
+    await knexInstance.raw('SELECT 1 + 1 AS sum;')
+
+    assert.equal(configCalls, 2)
+  }).timeout(8000)
 })


### PR DESCRIPTION
## Summary

- Make `acquireRawConnection` async across all dialects (pg, mysql, mssql, oracledb) so `configFn` can return a `Promise<ConnectionConfig>`. Inspired by #29.
- Mirror knex's native `connectionConfigProvider` semantics: cache resolved settings and only re-invoke `configFn` when the previously returned `expirationChecker` reports the credentials as stale.
- Strip `expirationChecker` from the settings object before handing it to the underlying driver, so drivers (e.g. mysql2) don't warn about unknown properties.

## Why

Allows downstream users to plug short-lived credential providers (IAM, Vault, etc.) into `patchKnex` and have credentials refreshed only when actually expired — instead of fetching a new token on every pool acquire.

## Behavior

- First acquire: `configFn` invoked, settings cached, `expirationChecker` stored.
- Subsequent acquires while `expirationChecker()` returns `false`: cached settings reused, `configFn` not called.
- When `expirationChecker()` returns `true`: `configFn` re-invoked, cache + checker refreshed.
- If `configFn` does not return an `expirationChecker`, behavior matches the previous always-fetch path.

## Note for downstream users

Knex marks `password` as non-enumerable on `this.config.connection` (via `setHiddenProperty`). This is **pre-existing knex behavior**, not introduced here. If your `configFn` builds the result via spread (`{ ...config.connection, extra }`) the password will silently be dropped. Use direct return (`return config.connection`) or explicit field copy instead. Spread/`Object.assign` patterns were already broken before this PR.

## Test plan

- [ ] `npm run test:pg`
- [ ] `npm run test:mysql`
- [ ] `npm run test:mysql2`
- [ ] `npm run test:mssql`
- [ ] New test `cache settings while expirationChecker returns false` asserts `configFn` is called once across two acquires while the checker returns false, then again after the checker flips to true.
- [ ] New tests `support async connection property in knex config` and `switch hosts via async connection property` exercise the knex-native `connection: async () => ({...})` pattern through the patched path.